### PR TITLE
Force redraw the calling VIM window after exec

### DIFF
--- a/plugin/browsereload-mac.vim
+++ b/plugin/browsereload-mac.vim
@@ -57,6 +57,9 @@ func! s:Reload(app, ...)
         exec l:appcmd . l:reloadcmd . l:devnull
     endif 
 
+    " Force redraw the calling VIM window, incase it doesn't restore
+    " original content cleanly after running exec.
+    redraw!
 endfunc
 
 " }}}


### PR DESCRIPTION
"redraw!" refreshes the original VIM content, which may disappear entirely
after running exec.
